### PR TITLE
Implemented updateStudentDonations

### DIFF
--- a/src/controllers/donation.controller.js
+++ b/src/controllers/donation.controller.js
@@ -35,6 +35,8 @@ import Supply from '../models/supply.model.js';
 
 const create = async (req,res) => {
     try {
+        console.log('inside create donation');
+        console.log(req.body);
         const donation = await Donation.create(req.body);
         const student_id = donation.student_id;
         const student = await Student.findById(student_id);
@@ -43,7 +45,7 @@ const create = async (req,res) => {
         const supply_id = donation.supply_id;
         const supply = await Supply.findById(supply_id);
         supply.donations.push(donation._id);
-        supply.save();
+        supply.save()
         return res.status(201).json(donation.toJSON());
     } catch (err) {
         return res.status(400).json({

--- a/src/controllers/donation.controller.js
+++ b/src/controllers/donation.controller.js
@@ -35,8 +35,6 @@ import Supply from '../models/supply.model.js';
 
 const create = async (req,res) => {
     try {
-        console.log('inside create donation');
-        console.log(req.body);
         const donation = await Donation.create(req.body);
         const student_id = donation.student_id;
         const student = await Student.findById(student_id);
@@ -45,7 +43,7 @@ const create = async (req,res) => {
         const supply_id = donation.supply_id;
         const supply = await Supply.findById(supply_id);
         supply.donations.push(donation._id);
-        supply.save()
+        supply.save();
         return res.status(201).json(donation.toJSON());
     } catch (err) {
         return res.status(400).json({

--- a/src/controllers/student.controller.js
+++ b/src/controllers/student.controller.js
@@ -125,9 +125,8 @@ const updateStudentDonations = async (req, res) => {
         let supplyBeingUpdatedId = supplyBeingUpdated.supply_id;
         let donationUpdated = false;
         for (let j=0; j<currDonations.length; j++) {
-            
-            let donation_id = currDonations[j];
-            let donation = await Donation.findById(donation_id);
+            const donation_id = currDonations[j];
+            const donation = await Donation.findById(donation_id);
             if(supplyBeingUpdatedId == donation.supply_id) {
                 donationUpdated = true;
                 donation.quantityDonated = supplyBeingUpdated.quantityDonated;
@@ -165,10 +164,6 @@ const updateStudentDonations = async (req, res) => {
     }));
     expandedDonations = {"donations": expandedDonations};
     return res.json(expandedDonations);
-};
-
-const createDonation = async donationData => {
-
 };
 
 export default { studentByID, create, remove, update, read, readStudentDonations, updateStudentDonations };

--- a/src/controllers/student.controller.js
+++ b/src/controllers/student.controller.js
@@ -71,19 +71,19 @@ const remove = async (req, res, next) => {
         // remove student from teacher's students array
         const teacher_id = student.teacher_id;
         const teacher = await Teacher.findById(teacher_id);
-        let student_index = teacher.students.indexOf(student_id);
+        const student_index = teacher.students.indexOf(student_id);
         if (student_index > -1) {
             teacher.students.splice(student_index, 1);
         }
         await teacher.save();
         // remove student's donations from each Supply that contains 
         // the student's donation
-        let donations = student.donations;
+        const donations = student.donations;
         donations.forEach(async(donation_id) => {
             const donation = await Donation.findById(donation_id);
-            let supply_id = donation.supply_id;
+            const supply_id = donation.supply_id;
             const supply = await Supply.findById(supply_id);
-            let donation_index = supply.donations.indexOf(donation_id);
+            const donation_index = supply.donations.indexOf(donation_id);
             if (donation_index > -1) {
                 supply.donations.splice(donation_index, 1);
             }
@@ -121,8 +121,8 @@ const updateStudentDonations = async (req, res) => {
     const updatedDonations = req.body.updatedDonations; // array of objects {supply_id, quantityDonated}
     let newDonationSupplies = [];
     for( let i=0; i<updatedDonations.length; i++) {
-        let supplyBeingUpdated = updatedDonations[i];
-        let supplyBeingUpdatedId = supplyBeingUpdated.supply_id;
+        const supplyBeingUpdated = updatedDonations[i];
+        const supplyBeingUpdatedId = supplyBeingUpdated.supply_id;
         let donationUpdated = false;
         for (let j=0; j<currDonations.length; j++) {
             const donation_id = currDonations[j];

--- a/src/controllers/student.controller.js
+++ b/src/controllers/student.controller.js
@@ -55,7 +55,6 @@ const update = async (req, res, next) => {
         //lodash extend - merges the changes from body with the record
         // from db
         student = extend(student, req.body);
-        student.updated = Date.now();
         await student.save();
         res.status(200).json(student.toJSON());
     } catch (err) {
@@ -67,8 +66,8 @@ const update = async (req, res, next) => {
 
 const remove = async (req, res, next) => {
     try {
-        let student = req.student;
-        let student_id = student._id;
+        const student = req.student;
+        const student_id = student._id;
         // remove student from teacher's students array
         const teacher_id = student.teacher_id;
         const teacher = await Teacher.findById(teacher_id);
@@ -101,8 +100,8 @@ const remove = async (req, res, next) => {
 };
 
 const readStudentDonations = async (req, res) => {
-    let student = req.student;
-    let donations = student.donations;
+    const student = req.student;
+    const donations = student.donations;
     // when array is sent back, item, quantityDonated is also included for front-end use
     let expandedDonations = await Promise.all(donations.map( async (donation_id) => {
         let donationObject = await Donation.findById(donation_id);
@@ -117,9 +116,59 @@ const readStudentDonations = async (req, res) => {
 };
 
 const updateStudentDonations = async (req, res) => {
-   // to be implemented
+    const student = req.student;
+    const currDonations = student.donations; // array of Donation items {donation_id, student_id, supply_id, quantityDonated}
+    const updatedDonations = req.body.updatedDonations; // array of objects {supply_id, quantityDonated}
+    let newDonationSupplies = [];
+    for( let i=0; i<updatedDonations.length; i++) {
+        let supplyBeingUpdated = updatedDonations[i];
+        let supplyBeingUpdatedId = supplyBeingUpdated.supply_id;
+        let donationUpdated = false;
+        for (let j=0; j<currDonations.length; j++) {
+            
+            let donation_id = currDonations[j];
+            let donation = await Donation.findById(donation_id);
+            if(supplyBeingUpdatedId == donation.supply_id) {
+                donationUpdated = true;
+                donation.quantityDonated = supplyBeingUpdated.quantityDonated;
+                await donation.save();
+            }
+        }
+        // supply not found in student's donations array so create new Donation
+        if(!donationUpdated) {
+            newDonationSupplies.push(supplyBeingUpdated);
+        }
+    }
+    for(let i=0; i<newDonationSupplies.length; i++) {
+        const newSupplyId = newDonationSupplies[i].supply_id;
+        const newQuantityDonated = newDonationSupplies[i].quantityDonated;
+        const donationData = {
+            student_id: student._id,
+            supply_id: newSupplyId,
+            quantityDonated: newQuantityDonated
+        }
+        const donation = await Donation.create(donationData);
+        student.donations.push(donation._id);
+        await student.save();
+        const supply_id = donation.supply_id;
+        const supply = await Supply.findById(supply_id);
+        supply.donations.push(donation._id);
+        await supply.save()
+    }
+    let expandedDonations = await Promise.all(student.donations.map( async (donation_id) => {
+        let donationObject = await Donation.findById(donation_id);
+        return {
+            donation_id: donationObject._id,
+            item: donationObject.item,
+            quantityDonated: donationObject.quantityDonated
+        }
+    }));
+    expandedDonations = {"donations": expandedDonations};
+    return res.json(expandedDonations);
 };
 
+const createDonation = async donationData => {
 
+};
 
 export default { studentByID, create, remove, update, read, readStudentDonations, updateStudentDonations };

--- a/src/controllers/supply.controller.js
+++ b/src/controllers/supply.controller.js
@@ -54,7 +54,6 @@ const update = async (req, res, next) => {
         //lodash extend - merges the changes from body with the record
         // from db
         supply = extend(supply, req.body);
-        supply.updated = Date.now();
         await supply.save();
         res.status(200).json(supply.toJSON());
     } catch (err) {

--- a/src/models/donation.model.js
+++ b/src/models/donation.model.js
@@ -15,18 +15,10 @@ const DonationSchema = new Schema({
         type: String,
         required: [true, 'supply_id is required']
     },
-    item: {
-        type: String,
-    },
    quantityDonated: {
         type: Number,
         required: [true,'quantityDonated is required']
     },
-    created: {
-        type: Date,
-        default: Date.now,
-    },
-    updated: Date,
 });
 
 DonationSchema.methods = {
@@ -36,7 +28,6 @@ DonationSchema.methods = {
             supply_id: this.supply_id,
             student_id: this.student_id,
             quantityDonated: this.quantityDonated,
-            item: this.item
         };
     },
 };

--- a/src/models/student.model.js
+++ b/src/models/student.model.js
@@ -26,11 +26,6 @@ const StudentSchema = new Schema({
     donations: [
         {type: Schema.Types.ObjectId, ref: 'Donation' }
     ],
-    created: {
-        type: Date,
-        default: Date.now,
-    },
-    updated: Date,
 });
 
 StudentSchema.methods = {

--- a/src/models/supply.model.js
+++ b/src/models/supply.model.js
@@ -20,12 +20,7 @@ const SupplySchema = new Schema({
     },
     donations: [
         {type: Schema.Types.ObjectId, ref: 'Donation' }
-    ],
-    created: {
-        type: Date,
-        default: Date.now,
-    },
-    updated: Date,
+    ]
 });
 
 SupplySchema.methods = {


### PR DESCRIPTION
This PR implements the endpoint that is sent to update a Student's donations array: PATCH /students/:student_id/donations

This is used when a student already has existing Donations, but is requesting to update their donations. For example, if they first submitted a donation form to donate 1 tissue box and 2 scissors, they may update their donation form to donate 2 tissue boxes, 0 scissors, and 1 pack of dry erase markers.

The student's donations array will be updated. If a donation doesn't already exist with the supply_id, then a new Donation is created and added to the student's donations array. If a donation already exists with the supply_id, then the quantityDonated field will be updated. For either case, the Supply with the supply_id must be updated, specifically its quantityDonated field. 
Note that if the quantityDonated field is set to 0, the Donation is not deleted. And if the Student is not donating any supplies (in the case that quantityDonated == 0 for all Donations), the Student is NOT deleted. 

In the request body supply_id’s are sent, but the donation_id’s are sent in the response.


More details about this end point in the [API documentation](https://docs.google.com/document/d/1P53wGkK7j7f1-2kQo2RL6Zrw9vHAHQD2pj5QAPY_bhQ/edit#) - scroll to the bottom of the doc.